### PR TITLE
Implemented to fetchAvailableTask without meta data

### DIFF
--- a/Buildfile
+++ b/Buildfile
@@ -7,7 +7,7 @@ require "buildr/xmlbeans"
 # Keep this structure to allow the build system to update version numbers.
 
 # This branch is a copy of Tempo 6.0.85
-VERSION_NUMBER = "7.0.0.000-SNAPSHOT"
+VERSION_NUMBER = "6.6.0.000-SNAPSHOT"
 
 require "rsc/build/dependencies.rb"
 require "rsc/build/repositories.rb"

--- a/tms-client/src/main/java/org/intalio/tempo/workflow/tms/client/LocalTMSClient.java
+++ b/tms-client/src/main/java/org/intalio/tempo/workflow/tms/client/LocalTMSClient.java
@@ -354,4 +354,12 @@ public class LocalTMSClient implements ITaskManagementService {
                 
     }
 
+    @Override
+    public Task[] getAvailableTasks(String taskType, String subQuery,
+            String first, String max, String fetchMetaData)
+            throws AuthException {
+        // TODO Auto-generated method stub
+        return null;
+    }
+
 }

--- a/tms-client/src/main/java/org/intalio/tempo/workflow/tms/client/RemoteTMSClient.java
+++ b/tms-client/src/main/java/org/intalio/tempo/workflow/tms/client/RemoteTMSClient.java
@@ -598,6 +598,10 @@ public class RemoteTMSClient implements ITaskManagementService {
     }
 
     public Task[] getAvailableTasks(final String taskType, final String subQuery, final String first, final String max) throws AuthException {
+        return getAvailableTasks(taskType, subQuery, first, max, null);
+    }
+
+    public Task[] getAvailableTasks(final String taskType, final String subQuery, final String first, final String max, final String fetchMetaData) throws AuthException {
         OMElement request = new TMSMarshaller() {
             public OMElement marshalRequest() {
                 OMElement request = createElement("getTaskListRequest");
@@ -606,6 +610,7 @@ public class RemoteTMSClient implements ITaskManagementService {
                 createElement(request, "subQuery", subQuery);
                 if(first!=null) createElement(request, "first", first);
                 if(max!=null) createElement(request, "max", max);
+                if(fetchMetaData!=null) createElement(request, "fetchMetaData", fetchMetaData);
                 return request;
             }
         }.marshalRequest();
@@ -619,7 +624,7 @@ public class RemoteTMSClient implements ITaskManagementService {
                 break;
 
             try {
-                Task task = new TaskUnmarshaller().unmarshalTaskFromMetadata(taskElement);
+                Task task = new TaskUnmarshaller().unmarshalTaskFromMetadata(taskElement, fetchMetaData);
                 tasks.add(task);
             } catch (Exception e) {
                 _log.error("Error reading task: " + taskElement, e);

--- a/tms-client/src/test/java/org/intalio/tempo/workflow/tms/client/dependent_tests/RemoteTMSClientTest.java
+++ b/tms-client/src/test/java/org/intalio/tempo/workflow/tms/client/dependent_tests/RemoteTMSClientTest.java
@@ -234,4 +234,60 @@ public class RemoteTMSClientTest extends TestCase {
         _logger.debug(task2.getRoleOwners().toString());
         tms.deletePipa(task1.getProcessEndpoint().toString());
     }
+
+    public void testGetAvailableTaskWithMetaData() throws Exception {
+        try {
+            ITaskManagementService tms = new TMSFactory().configureRemote()
+                    .getService(TMS_REMOTE_URL, TOKEN);
+            Task[] tasks = tms.getAvailableTasks("PATask", "", "0", "1");
+            _logger.info("Total number of task retrived: " + tasks.length);
+            Assert.assertNotNull(tasks);
+            if (tasks.length == 1) {
+                PATask task = ((PATask) tasks[0]);
+                Assert.assertNotNull(task.getDescription());
+                Assert.assertNotNull(task.getCreationDate());
+                Assert.assertNotNull(task.getFormURL());
+                Assert.assertNotNull(task.getCustomMetadata());
+                Assert.assertNotNull(task.getState());
+                Assert.assertNotNull(task.getID());
+            }
+
+            tasks = tms.getAvailableTasks("PATask", "", "0", "1", "true");
+            _logger.info("Total number of task retrived: " + tasks.length);
+            Assert.assertNotNull(tasks);
+            if (tasks.length == 1) {
+                PATask task = ((PATask) tasks[0]);
+                Assert.assertNotNull(task.getDescription());
+                Assert.assertNotNull(task.getCreationDate());
+                Assert.assertNotNull(task.getFormURL());
+                Assert.assertNotNull(task.getCustomMetadata());
+                Assert.assertNotNull(task.getState());
+                Assert.assertNotNull(task.getID());
+            }
+        } catch (Exception e) {
+            assertTrue(false);
+        }
+    }
+
+    public void testGetAvailableTaskWithoutMetaData() {
+        try {
+            ITaskManagementService tms = new TMSFactory().configureRemote()
+                    .getService(TMS_REMOTE_URL, TOKEN);
+            Task[] tasks = tms.getAvailableTasks("PATask", "", "0", "1",
+                    "false");
+            _logger.info("Total number of task retrived: " + tasks.length);
+            Assert.assertNotNull(tasks);
+            if (tasks.length == 1) {
+                PATask task = ((PATask) tasks[0]);
+                Assert.assertNotNull(task.getDescription());
+                Assert.assertNotNull(task.getState());
+                Assert.assertNotNull(task.getID());
+                _logger.info("Tasks details: [description: "
+                        + task.getDescription() + ", state: " + task.getState()
+                        + ", id: " + task.getID() + "]");
+            }
+        } catch (Exception e) {
+            assertTrue(false);
+        }
+    }
 }

--- a/tms-common/src/main/java/org/intalio/tempo/workflow/task/PATask.java
+++ b/tms-common/src/main/java/org/intalio/tempo/workflow/task/PATask.java
@@ -130,7 +130,7 @@ public class PATask extends Task implements ITaskWithState, IProcessBoundTask, I
     private String _instanceId;
     
     @PersistentMap(keyCascade = CascadeType.ALL, elementCascade = CascadeType.ALL, keyType = String.class, 
-    		elementType=String.class, fetch=FetchType.EAGER)
+            elementType=String.class, fetch=FetchType.LAZY)
     @ContainerTable(name="tempo_generic")
     private Map<String, String> _customMetadata;
     

--- a/tms-common/src/main/java/org/intalio/tempo/workflow/task/Task.java
+++ b/tms-common/src/main/java/org/intalio/tempo/workflow/task/Task.java
@@ -106,7 +106,7 @@ public abstract class Task extends BaseRestrictedEntity {
         return _id;
     }
 
-    private void setID(String id) {
+    public void setID(String id) {
         if (id == null) {
             throw new RequiredArgumentException("id");
         }

--- a/tms-common/src/main/java/org/intalio/tempo/workflow/task/xml/TaskTypeMapper.java
+++ b/tms-common/src/main/java/org/intalio/tempo/workflow/task/xml/TaskTypeMapper.java
@@ -83,4 +83,12 @@ public final class TaskTypeMapper {
             throw new IllegalArgumentException("Cannot instanciate class type: " + taskClass.getName());
         }
     }
+
+    public static Task getNewInstance(Class<? extends Task> taskClass) {
+        try {
+            return (Task) taskClass.getConstructor().newInstance();
+        } catch (Exception e) {
+            throw new IllegalArgumentException("Cannot instanciate class type: " + taskClass.getName());
+        }
+    }
 }

--- a/tms-common/src/main/java/org/intalio/tempo/workflow/tms/ITaskManagementService.java
+++ b/tms-common/src/main/java/org/intalio/tempo/workflow/tms/ITaskManagementService.java
@@ -38,6 +38,8 @@ public interface ITaskManagementService {
     
     Task[] getAvailableTasks(final String taskType, final String subQuery, final String first, final String max) throws AuthException;
 
+    Task[] getAvailableTasks(final String taskType, final String subQuery, final String first, final String max, final String fetchMetaData) throws AuthException;
+
     Task getTask(String taskID) throws AuthException, UnavailableTaskException;
 
     void setOutput(String taskID, Document output) throws AuthException, UnavailableTaskException, InvalidTaskStateException;

--- a/tms-common/src/main/java/org/intalio/tempo/workflow/util/jpa/TaskFetcher.java
+++ b/tms-common/src/main/java/org/intalio/tempo/workflow/util/jpa/TaskFetcher.java
@@ -42,7 +42,7 @@ public class TaskFetcher {
 	final static Logger _logger = LoggerFactory.getLogger(TaskFetcher.class);
 	private EntityManager _entityManager;
 	private Query find_by_id;
-	private final String QUERY_GENERIC1 = "select DISTINCT T from ";
+	private final String QUERY_GENERIC1 = "select T from ";
 	private final String QUERY_GENERIC_COUNT = "select COUNT(DISTINCT T) from ";
 //	private final String QUERY_GENERIC2 = " T where (T._userOwners = (?1) or T._roleOwners = (?2)) ";
 	private final String QUERY_GENERIC2_FOR_ADMIN = " T ";

--- a/tms-service/src/main/axis2/TaskManagementService.wsdl
+++ b/tms-service/src/main/axis2/TaskManagementService.wsdl
@@ -358,6 +358,7 @@
                         <xsd:element name="subQuery" type="xsd:string"/>
                         <xsd:element name="first" type="xsd:string" minOccurs="0"/>
                         <xsd:element name="max" type="xsd:string" minOccurs="0"/>
+                        <xsd:element name="fetchMetaData" type="xsd:string" minOccurs="0"/>
                     </xsd:sequence>
                 </xsd:complexType>
             </xsd:element>

--- a/tms-service/src/main/java/org/intalio/tempo/workflow/tms/server/TMSRequestProcessor.java
+++ b/tms-service/src/main/java/org/intalio/tempo/workflow/tms/server/TMSRequestProcessor.java
@@ -646,6 +646,7 @@ public class TMSRequestProcessor extends OMUnmarshaller {
             String subQuery = requireElementValue(rootQueue, "subQuery");
             String first = expectElementValue(rootQueue, "first");
             String max = expectElementValue(rootQueue, "max");
+            String fetchMetaData = expectElementValue(rootQueue, "fetchMetaData");
             HashMap map = new HashMap();
             map.put(TaskFetcher.FETCH_CLASS_NAME, taskType);
             map.put(TaskFetcher.FETCH_SUB_QUERY, subQuery);
@@ -653,7 +654,7 @@ public class TMSRequestProcessor extends OMUnmarshaller {
             map.put(TaskFetcher.FETCH_MAX, max);
             final UserRoles user = _server.getUserRoles(participantToken);
             Task[] tasks = _server.getAvailableTasks(dao,participantToken, map);
-            return marshalTasksList(user, tasks, "getAvailableTasksResponse");
+            return marshalTasksList(user, tasks, "getAvailableTasksResponse", fetchMetaData);
         } catch (Exception e) {
             throw makeFault(e);
         }
@@ -700,12 +701,16 @@ public class TMSRequestProcessor extends OMUnmarshaller {
      * <code>getTaskList</code>
      */
     private OMElement marshalTasksList(final UserRoles user, final Task[] tasks, final String responseTag) {
+        return marshalTasksList(user, tasks, responseTag, null);
+    }
+
+    private OMElement marshalTasksList(final UserRoles user, final Task[] tasks, final String responseTag, final String fetchMetaData) {
         OMElement response = new TMSResponseMarshaller(OM_FACTORY) {
             public OMElement marshalResponse(Task[] tasks) {
                 OMElement response = createElement(responseTag);
                 for (Task task : tasks) {
                     try {
-                        response.addChild(new TaskMarshaller().marshalTaskMetadata(task, user));
+                        response.addChild(new TaskMarshaller().marshalTaskMetadata(task, user, fetchMetaData));
                     } catch (Exception e) {
                         // marshalling of that task failed.
                         // let's not fail fast, but provide info in the logs.
@@ -719,7 +724,6 @@ public class TMSRequestProcessor extends OMUnmarshaller {
             _logger.debug(response.toString());
         return response;
     }
-
     private AxisFault makeFault(Exception e) {
         if (e instanceof TMSException) {
             if (_logger.isDebugEnabled())


### PR DESCRIPTION
Commits:
    Implemented to fetchAvailableTask without meta data
    Implemented to fetchAvailableTask from RemoteTMSClient without meta data
    Removed DISTINCT from getAvailableTasks query
    Changed the version number strategy
